### PR TITLE
fixed checkbox selected for labels and categories when validation fails

### DIFF
--- a/resources/views/tickets/edit.blade.php
+++ b/resources/views/tickets/edit.blade.php
@@ -35,7 +35,7 @@
                         <div class="mt-1 inline-flex space-x-1">
                             <input class="text-purple-600 form-checkbox focus:shadow-outline-purple focus:border-purple-400 focus:outline-none"
                                    type="checkbox" name="labels[]" id="label-{{ $id }}" value="{{ $id }}"
-                                    @checked(in_array($id, old('labels', [])) || $ticket->labels->contains($id))>
+                                    @checked(old('labels') ? in_array($id, old('labels', [])) : $ticket->labels->contains($id))>
                             <x-input-label for="label-{{ $id }}">{{ $name }}</x-input-label>
                         </div>
                     @endforeach
@@ -48,7 +48,7 @@
                         <div class="mt-1 inline-flex space-x-1">
                             <input class="text-purple-600 form-checkbox focus:shadow-outline-purple focus:border-purple-400 focus:outline-none"
                                    type="checkbox" name="categories[]" id="category-{{ $id }}" value="{{ $id }}"
-                                    @checked(in_array($id, old('categories', [])) || $ticket->categories->contains($id))>
+                                    @checked(old('categories') ? in_array($id, old('categories', [])) : $ticket->categories->contains($id))>
                             <x-input-label for="category-{{ $id }}">{{ $name }}</x-input-label>
                         </div>
                     @endforeach


### PR DESCRIPTION
inside tickets edit page, whenever user chooses a new selection on either labels or categories field and backend validation fails for example the title or message field, it reverts back to their original selected checkbox options. (note that title and message field are protected by frontend validation but that could change in the future)